### PR TITLE
change path and filename to fit to the TAOS test

### DIFF
--- a/plotres.py
+++ b/plotres.py
@@ -27,7 +27,7 @@ def main():
 
     cov=False
     nside=-1
-    outname='demo'
+    outname='demo_map'
     cmap='jet'
     docart=False
     vmin=-3
@@ -63,11 +63,11 @@ def main():
     else:
         import foscat.scat as sc
 
-    refX  = sc.read('in2d_%s_%d'%(outname,nside))
-    start = sc.read('st2d_%s_%d'%(outname,nside))
-    out   = sc.read('out2d_%s_%d'%(outname,nside))
+    refX  = sc.read('./data/in2d_%s_%d'%(outname,nside))
+    start = sc.read('./data/st2d_%s_%d'%(outname,nside))
+    out   = sc.read('./data/out2d_%s_%d'%(outname,nside))
 
-    log= np.load('out2d_%s_log_%d.npy'%(outname,nside))
+    log= np.load('./data/out2d_%s_log_%d.npy'%(outname,nside))
     plt.figure(figsize=(6,6))
     plt.plot(np.arange(log.shape[0])+1,log,color='black')
     plt.xscale('log')
@@ -80,11 +80,11 @@ def main():
     out.plot(name='Output',color='red',hold=False)
     #(refX-out).plot(name='Diff',color='purple',hold=False)
 
-    sst = np.load('sst2d_%s_map_%d.npy'%(outname,nside))
-    im = np.load('in2d_%s_map_%d.npy'%(outname,nside))
-    sm = np.load('st2d_%s_map_%d.npy'%(outname,nside))
-    tsm= np.load('stm2d_%s_map_%d.npy'%(outname,nside))
-    om = np.load('out2d_%s_map_%d.npy'%(outname,nside))
+    sst = np.load('./data/sst2d_%s_map_%d.npy'%(outname,nside))
+    im = np.load('./data/in2d_%s_map_%d.npy'%(outname,nside))
+    sm = np.load('./data/st2d_%s_map_%d.npy'%(outname,nside))
+    tsm= np.load('./data/stm2d_%s_map_%d.npy'%(outname,nside))
+    om = np.load('./data/out2d_%s_map_%d.npy'%(outname,nside))
 
     n=im.shape[0]
     plt.figure(figsize=(10,6))

--- a/plotres.py
+++ b/plotres.py
@@ -15,7 +15,7 @@ def usage():
     print('--vmin|-i    (optional): specify the minimum value')
     print('--vmax|-a    (optional): specify the maximum value')
     exit(0)
-    
+
 def main():
     try:
         opts, args = getopt.getopt(sys.argv[1:], "n:co:m:gi:a:", ["nside", "cov","out","map","geo","vmin","vmax"])
@@ -27,12 +27,12 @@ def main():
 
     cov=False
     nside=-1
-    outname='demo_map'
+    outname='demo'
     cmap='jet'
     docart=False
     vmin=-3
     vmax=3
-    
+
     for o, a in opts:
         if o in ("-c","--cov"):
             cov = True

--- a/plotresM.py
+++ b/plotresM.py
@@ -27,7 +27,7 @@ def main():
 
     cov=False
     nside=-1
-    outname='demo'
+    outname='demo_map'
     cmap='jet'
     docart=False
     vmin=-3
@@ -64,7 +64,9 @@ def main():
         import foscat.scat as sc
 
 
-    log= np.load('out2d_%s_log_%d.npy'%(outname,nside))
+    outname='demo_map'
+    log= np.load('./data/out2dM_%s_log_%d.npy'%(outname,nside))
+#    log= np.load('./data/out2dM_demo_log_128.npy') #name,nside))
     plt.figure(figsize=(6,6))
     plt.plot(np.arange(log.shape[0])+1,log,color='black')
     plt.xscale('log')
@@ -72,13 +74,13 @@ def main():
     plt.ylabel('Loss')
     plt.xlabel('Number of iteration')
     
-    sst = np.load('sst2dM_%s_map_%d.npy'%(outname,nside))
-    im = np.load('in2dM_%s_map_%d.npy'%(outname,nside))
-    sm = np.load('st2dM_%s_map_%d.npy'%(outname,nside))
-    om = np.load('out2dM_%s_map_%d.npy'%(outname,nside))
+    sst = np.load('./data/sst2dM_%s_map_%d.npy'%(outname,nside))
+    im = np.load('./data/in2dM_%s_map_%d.npy'%(outname,nside))
+    sm = np.load('./data/st2dM_%s_map_%d.npy'%(outname,nside))
+    om = np.load('./data/out2dM_%s_map_%d.npy'%(outname,nside))
 
-    start = sc.read('st2dM%d_%s_%d'%(0,outname,nside))
-    out   = sc.read('out2dM%d_%s_%d'%(0,outname,nside))
+    start = sc.read('./data/st2dM%d_%s_%d'%(0,outname,nside))
+    out   = sc.read('./data/out2dM%d_%s_%d'%(0,outname,nside))
     start.plot(name='Input',color='orange')
     out.plot(name='Output',color='red',hold=False)
     


### PR DESCRIPTION
Loading *npy files works but it gives following error messages
```
 % python plotresM.py -n=128 -c
Work with nside=128
Traceback (most recent call last):
  File "/Users/todaka/python/git/TAOS/plotresM.py", line 109, in <module>
    main()
  File "/Users/todaka/python/git/TAOS/plotresM.py", line 71, in main
    plt.plot(np.arange(log.shape[0])+1,log,color='black')
  File "/Users/todaka/micromamba/envs/fosscat_demo/lib/python3.9/site-packages/matplotlib/pyplot.py", line 2812, in plot
    return gca().plot(
  File "/Users/todaka/micromamba/envs/fosscat_demo/lib/python3.9/site-packages/matplotlib/axes/_axes.py", line 1688, in plot
    lines = [*self._get_lines(*args, data=data, **kwargs)]
  File "/Users/todaka/micromamba/envs/fosscat_demo/lib/python3.9/site-packages/matplotlib/axes/_base.py", line 311, in __call__
    yield from self._plot_args(
  File "/Users/todaka/micromamba/envs/fosscat_demo/lib/python3.9/site-packages/matplotlib/axes/_base.py", line 507, in _plot_args
    raise ValueError(f"x and y can be no greater than 2D, but have "
ValueError: x and y can be no greater than 2D, but have shapes (8,) and (8, 128, 128)
(fosscat_demo) todaka@workbook TAOS %
```